### PR TITLE
Allow creating sessions without nesting

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ go install
 
 ## Usage
 
-`smug <command> <project>[:window name] [-w window name]`.
+`smug <command> <project>[:window name] [--force] [-w window name]`.
 
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ go install
 
 ## Usage
 
-`smug <command> <project>[:window name] [--force] [-w window name]`.
+`smug <command> <project>[:window name] [-w window name]... [--attach]`.
 
 ### Examples
 

--- a/main.go
+++ b/main.go
@@ -39,7 +39,11 @@ func main() {
 
 	switch options.Command {
 	case "start":
-		fmt.Println("Starting a new session...")
+		if len(options.Windows) == 0 {
+			fmt.Println("Starting a new session...")
+		} else {
+			fmt.Println("Starting new windows...")
+		}
 		err = smug.Start(*config, options.Windows, options.Attach)
 		if err != nil {
 			fmt.Println("Oops, an error occurred! Rolling back...")

--- a/main.go
+++ b/main.go
@@ -40,7 +40,7 @@ func main() {
 	switch options.Command {
 	case "start":
 		fmt.Println("Starting a new session...")
-		err = smug.Start(*config, options.Windows)
+		err = smug.Start(*config, options.Windows, options.Force)
 		if err != nil {
 			fmt.Println("Oops, an error occurred! Rolling back...")
 			smug.Stop(*config, options.Windows)

--- a/main.go
+++ b/main.go
@@ -40,7 +40,7 @@ func main() {
 	switch options.Command {
 	case "start":
 		fmt.Println("Starting a new session...")
-		err = smug.Start(*config, options.Windows, options.Force)
+		err = smug.Start(*config, options.Windows, options.Attach)
 		if err != nil {
 			fmt.Println("Oops, an error occurred! Rolling back...")
 			smug.Stop(*config, options.Windows)

--- a/options.go
+++ b/options.go
@@ -9,10 +9,11 @@ import (
 const usage = `Smug - tmux session manager.
 
 Usage:
-	smug <command> <project> [-w <window>]...
+	smug <command> <project> [--force] [-w <window>] ...
 
 Options:
 	-w List of windows to start. If session exists, those windows will be attached to current session.
+	-s Switch client to a created session when ran inside a tmux session
 
 Examples:
 	$ smug start blog
@@ -26,6 +27,7 @@ type Options struct {
 	Command string
 	Project string
 	Windows []string
+	Force   bool
 }
 
 func ParseOptions(p docopt.Parser, argv []string) (Options, error) {
@@ -47,6 +49,11 @@ func ParseOptions(p docopt.Parser, argv []string) (Options, error) {
 		return Options{}, err
 	}
 
+	force, err := arguments.Bool("--force")
+	if err != nil {
+		return Options{}, err
+	}
+
 	var windows []string
 
 	if strings.Contains(project, ":") {
@@ -57,5 +64,5 @@ func ParseOptions(p docopt.Parser, argv []string) (Options, error) {
 		windows = arguments["-w"].([]string)
 	}
 
-	return Options{cmd, project, windows}, nil
+	return Options{cmd, project, windows, force}, nil
 }

--- a/options.go
+++ b/options.go
@@ -9,11 +9,10 @@ import (
 const usage = `Smug - tmux session manager.
 
 Usage:
-	smug <command> <project> [--force] [-w <window>] ...
+	smug <command> <project> [-w <window>]... [--attach]
 
 Options:
 	-w List of windows to start. If session exists, those windows will be attached to current session.
-	-s Switch client to a created session when ran inside a tmux session
 
 Examples:
 	$ smug start blog
@@ -27,29 +26,26 @@ type Options struct {
 	Command string
 	Project string
 	Windows []string
-	Force   bool
+	Attach  bool
 }
 
 func ParseOptions(p docopt.Parser, argv []string) (Options, error) {
 	arguments, err := p.ParseArgs(usage, argv, "")
-
 	if err != nil {
 		return Options{}, err
 	}
 
 	cmd, err := arguments.String("<command>")
-
 	if err != nil {
 		return Options{}, err
 	}
 
 	project, err := arguments.String("<project>")
-
 	if err != nil {
 		return Options{}, err
 	}
 
-	force, err := arguments.Bool("--force")
+	attach, err := arguments.Bool("--attach")
 	if err != nil {
 		return Options{}, err
 	}
@@ -64,5 +60,5 @@ func ParseOptions(p docopt.Parser, argv []string) (Options, error) {
 		windows = arguments["-w"].([]string)
 	}
 
-	return Options{cmd, project, windows, force}, nil
+	return Options{cmd, project, windows, attach}, nil
 }

--- a/options_test.go
+++ b/options_test.go
@@ -24,7 +24,7 @@ var usageTestTable = []struct {
 		Options{"start", "smug", []string{"foo", "bar"}, false},
 	},
 	{
-		[]string{"start", "smug", "--force"},
+		[]string{"start", "smug", "--attach"},
 		Options{"start", "smug", []string{}, true},
 	},
 }

--- a/options_test.go
+++ b/options_test.go
@@ -13,15 +13,19 @@ var usageTestTable = []struct {
 }{
 	{
 		[]string{"start", "smug"},
-		Options{"start", "smug", []string{}},
+		Options{"start", "smug", []string{}, false},
 	},
 	{
 		[]string{"start", "smug", "-wfoo"},
-		Options{"start", "smug", []string{"foo"}},
+		Options{"start", "smug", []string{"foo"}, false},
 	},
 	{
 		[]string{"start", "smug:foo,bar"},
-		Options{"start", "smug", []string{"foo", "bar"}},
+		Options{"start", "smug", []string{"foo", "bar"}, false},
+	},
+	{
+		[]string{"start", "smug", "--force"},
+		Options{"start", "smug", []string{}, true},
 	},
 }
 

--- a/smug.go
+++ b/smug.go
@@ -102,7 +102,7 @@ func (smug Smug) Start(config Config, windows []string, attach bool) error {
 			defaultWindowName = config.Windows[0].Name
 		}
 
-		ses, err = smug.tmux.NewSession(config.Session, defaultWindowName)
+		ses, err = smug.tmux.NewSession(config.Session, sessionRoot, defaultWindowName)
 		if err != nil {
 			return err
 		}

--- a/smug.go
+++ b/smug.go
@@ -72,7 +72,7 @@ func (smug Smug) Stop(config Config, windows []string) error {
 	return nil
 }
 
-func (smug Smug) Start(config Config, windows []string, force bool) error {
+func (smug Smug) Start(config Config, windows []string, attach bool) error {
 	var ses string
 	var err error
 
@@ -155,8 +155,8 @@ func (smug Smug) Start(config Config, windows []string, force bool) error {
 	}
 
 	if len(windows) == 0 {
-		// If Smug ran inside tmux session and user passed --force flag to switch client
-		if os.Getenv("TERM") == "screen" && force {
+		// If Smug ran inside tmux session and user passed --attach flag to switch client
+		if os.Getenv("TERM") == "screen" && attach {
 			err = smug.tmux.SwitchClient(ses)
 		} else {
 

--- a/smug_test.go
+++ b/smug_test.go
@@ -23,7 +23,7 @@ var testTable = []struct {
 			"tmux has-session -t ses",
 			"/bin/sh -c command1",
 			"/bin/sh -c command2",
-			"tmux new -Pd -s ses -n ",
+			"tmux new -Pd -s ses -n  -c root",
 			"tmux attach -d -t ses:",
 		},
 		[]string{
@@ -59,7 +59,7 @@ var testTable = []struct {
 		},
 		[]string{
 			"tmux has-session -t ses",
-			"tmux new -Pd -s ses -n win1",
+			"tmux new -Pd -s ses -n win1 -c root",
 			"tmux split-window -Pd -t ses:win1 -c root -h",
 			"tmux select-layout -t ses:win1 main-horizontal",
 			"tmux attach -d -t ses:",
@@ -88,7 +88,7 @@ var testTable = []struct {
 		},
 		[]string{
 			"tmux has-session -t ses",
-			"tmux new -Pd -s ses -n win2",
+			"tmux new -Pd -s ses -n win2 -c root",
 			"tmux select-layout -t ses:win2 even-horizontal",
 		},
 		[]string{

--- a/smug_test.go
+++ b/smug_test.go
@@ -23,11 +23,8 @@ var testTable = []struct {
 			"tmux has-session -t ses",
 			"/bin/sh -c command1",
 			"/bin/sh -c command2",
-			"tmux new -Pd -s ses",
-			"tmux list-windows -t ses: -F #{window_index}",
-			"tmux kill-window -t ses:ses:",
-			"tmux move-window -r",
-			"tmux attach -t ses:ses:",
+			"tmux new -Pd -s ses -n ",
+			"tmux attach -d -t ses:",
 		},
 		[]string{
 			"tmux kill-session -t ses",
@@ -62,14 +59,10 @@ var testTable = []struct {
 		},
 		[]string{
 			"tmux has-session -t ses",
-			"tmux new -Pd -s ses",
-			"tmux neww -Pd -t ses: -n win1 -c root",
-			"tmux split-window -Pd -t ses: -c root -h",
+			"tmux new -Pd -s ses -n win1",
+			"tmux split-window -Pd -t ses:win1 -c root -h",
 			"tmux select-layout -t ses:win1 main-horizontal",
-			"tmux list-windows -t ses: -F #{window_index}",
-			"tmux kill-window -t ses:ses:",
-			"tmux move-window -r",
-			"tmux attach -t ses:ses:",
+			"tmux attach -d -t ses:",
 		},
 		[]string{
 			"/bin/sh -c stop1",
@@ -95,8 +88,7 @@ var testTable = []struct {
 		},
 		[]string{
 			"tmux has-session -t ses",
-			"tmux new -Pd -s ses",
-			"tmux neww -Pd -t ses: -n win2 -c root",
+			"tmux new -Pd -s ses -n win2",
 			"tmux select-layout -t ses:win2 even-horizontal",
 		},
 		[]string{
@@ -131,7 +123,7 @@ func TestStartSession(t *testing.T) {
 			tmux := Tmux{commander}
 			smug := Smug{tmux, commander}
 
-			err := smug.Start(params.config, params.windows)
+			err := smug.Start(params.config, params.windows, false)
 			if err != nil {
 				t.Fatalf("error %v", err)
 			}

--- a/tmux.go
+++ b/tmux.go
@@ -23,8 +23,8 @@ type Tmux struct {
 	commander Commander
 }
 
-func (tmux Tmux) NewSession(name string, windowName string) (string, error) {
-	cmd := exec.Command("tmux", "new", "-Pd", "-s", name, "-n", windowName)
+func (tmux Tmux) NewSession(name string, root string, windowName string) (string, error) {
+	cmd := exec.Command("tmux", "new", "-Pd", "-s", name, "-n", windowName, "-c", root)
 	return tmux.commander.Exec(cmd)
 }
 

--- a/tmux.go
+++ b/tmux.go
@@ -23,8 +23,8 @@ type Tmux struct {
 	commander Commander
 }
 
-func (tmux Tmux) NewSession(name string) (string, error) {
-	cmd := exec.Command("tmux", "new", "-Pd", "-s", name)
+func (tmux Tmux) NewSession(name string, windowName string) (string, error) {
+	cmd := exec.Command("tmux", "new", "-Pd", "-s", name, "-n", windowName)
 	return tmux.commander.Exec(cmd)
 }
 
@@ -40,22 +40,10 @@ func (tmux Tmux) KillWindow(target string) error {
 	return err
 }
 
-func (tmux Tmux) NewWindow(target string, name string, root string, commands []string) (string, error) {
+func (tmux Tmux) NewWindow(target string, name string, root string) (string, error) {
 	cmd := exec.Command("tmux", "neww", "-Pd", "-t", target, "-n", name, "-c", root)
 
-	window, err := tmux.commander.Exec(cmd)
-	if err != nil {
-		return "", err
-	}
-
-	for _, c := range commands {
-		err = tmux.SendKeys(window, c)
-		if err != nil {
-			return "", err
-		}
-	}
-
-	return window, nil
+	return tmux.commander.Exec(cmd)
 }
 
 func (tmux Tmux) SendKeys(target string, command string) error {
@@ -65,7 +53,7 @@ func (tmux Tmux) SendKeys(target string, command string) error {
 }
 
 func (tmux Tmux) Attach(target string, stdin *os.File, stdout *os.File, stderr *os.File) error {
-	cmd := exec.Command("tmux", "attach", "-t", target)
+	cmd := exec.Command("tmux", "attach", "-d", "-t", target)
 
 	cmd.Stdin = stdin
 	cmd.Stdout = stdout
@@ -74,7 +62,7 @@ func (tmux Tmux) Attach(target string, stdin *os.File, stdout *os.File, stderr *
 	return tmux.commander.ExecSilently(cmd)
 }
 
-func (tmux Tmux) RenumberWindows() error {
+func (tmux Tmux) RenumberWindows(target string) error {
 	cmd := exec.Command("tmux", "move-window", "-r")
 	_, err := tmux.commander.Exec(cmd)
 	return err
@@ -126,4 +114,9 @@ func (tmux Tmux) ListWindows(target string) ([]string, error) {
 	}
 
 	return strings.Split(output, "\n"), nil
+}
+
+func (tmux Tmux) SwitchClient(target string) error {
+	cmd := exec.Command("tmux", "switch-client", "-t", target)
+	return tmux.commander.ExecSilently(cmd)
 }


### PR DESCRIPTION
This one closes #15
 
Now, if a user runs Smug inside another Tmux session, a new session will be created. If they want to switch to that session immediately, there's a new `--attach` flag for this. 