### PR TITLE
Create edit commands

### DIFF
--- a/main.go
+++ b/main.go
@@ -58,7 +58,7 @@ func main() {
 	}
 
 	f, err := ioutil.ReadFile(configPath)
-	if err != nil {
+	if options.Command != "create" && err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
 	}
@@ -97,9 +97,16 @@ func main() {
 			fmt.Println("Oops, an error occurred! Rolling back...")
 			smug.Stop(*config, options, context)
 		}
+	case CommandCreate:
+		err = smug.Create(options)
+		if err != nil {
+			fmt.Println("Oops, an error occurred! Unable to create file...")
+		}
 	case CommandEdit:
-		smug.Edit(options)
-
+		err = smug.Edit(options)
+		if err != nil {
+			fmt.Println("Oops, an error occurred! Unable to edit file...")
+		}
 	case CommandStop:
 		if len(options.Windows) == 0 {
 			fmt.Println("Terminating session...")

--- a/main.go
+++ b/main.go
@@ -58,7 +58,7 @@ func main() {
 	}
 
 	f, err := ioutil.ReadFile(configPath)
-	if options.Command != "create" && err != nil {
+	if options.Command != CommandCreate && err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
 	}
@@ -81,7 +81,7 @@ func main() {
 
 	commander := DefaultCommander{logger}
 	tmux := Tmux{commander}
-	smug := Smug{tmux, commander}
+	smug := Smug{tmux, commander, configPath}
 
 	context := CreateContext()
 
@@ -98,17 +98,9 @@ func main() {
 			smug.Stop(*config, options, context)
 		}
 	case CommandCreate:
-		fmt.Printf("Creating %s...\n", options.Project)
 		err = smug.Create(options)
-		if err != nil {
-			fmt.Println("Oops, an error occurred! Unable to create file...")
-		}
 	case CommandEdit:
-		fmt.Printf("Opening %s in editor...\n", options.Project)
 		err = smug.Edit(options)
-		if err != nil {
-			fmt.Println("Oops, an error occurred! Unable to edit file...")
-		}
 	case CommandStop:
 		if len(options.Windows) == 0 {
 			fmt.Println("Terminating session...")

--- a/main.go
+++ b/main.go
@@ -98,11 +98,13 @@ func main() {
 			smug.Stop(*config, options, context)
 		}
 	case CommandCreate:
+		fmt.Printf("Creating %s...\n", options.Project)
 		err = smug.Create(options)
 		if err != nil {
 			fmt.Println("Oops, an error occurred! Unable to create file...")
 		}
 	case CommandEdit:
+		fmt.Printf("Opening %s in editor...\n", options.Project)
 		err = smug.Edit(options)
 		if err != nil {
 			fmt.Println("Oops, an error occurred! Unable to edit file...")

--- a/main.go
+++ b/main.go
@@ -29,6 +29,8 @@ Examples:
 	$ smug start blog:win1,win2
 	$ smug stop blog
 	$ smug start blog --attach
+	$ smug create blog
+	$ smug edit blog
 `, version, FileUsage, WindowsUsage, AttachUsage, DebugUsage)
 
 func main() {
@@ -95,6 +97,9 @@ func main() {
 			fmt.Println("Oops, an error occurred! Rolling back...")
 			smug.Stop(*config, options, context)
 		}
+	case CommandEdit:
+		smug.Edit(options)
+
 	case CommandStop:
 		if len(options.Windows) == 0 {
 			fmt.Println("Terminating session...")

--- a/main.go
+++ b/main.go
@@ -98,9 +98,9 @@ func main() {
 			smug.Stop(*config, options, context)
 		}
 	case CommandCreate:
-		err = smug.Create(options)
+		err = smug.Create()
 	case CommandEdit:
-		err = smug.Edit(options)
+		err = smug.Edit()
 	case CommandStop:
 		if len(options.Windows) == 0 {
 			fmt.Println("Terminating session...")

--- a/options.go
+++ b/options.go
@@ -10,9 +10,10 @@ import (
 const (
 	CommandStart = "start"
 	CommandStop  = "stop"
+	CommandEdit  = "edit"
 )
 
-var validCommands = []string{CommandStart, CommandStop}
+var validCommands = []string{CommandStart, CommandStop, CommandEdit}
 
 type Options struct {
 	Command string

--- a/options.go
+++ b/options.go
@@ -8,12 +8,13 @@ import (
 )
 
 const (
-	CommandStart = "start"
-	CommandStop  = "stop"
-	CommandEdit  = "edit"
+	CommandStart  = "start"
+	CommandStop   = "stop"
+	CommandCreate = "create"
+	CommandEdit   = "edit"
 )
 
-var validCommands = []string{CommandStart, CommandStop, CommandEdit}
+var validCommands = []string{CommandStart, CommandStop, CommandCreate, CommandEdit}
 
 type Options struct {
 	Command string

--- a/smug.go
+++ b/smug.go
@@ -57,6 +57,34 @@ func (smug Smug) switchOrAttach(sessionName string, attach bool, insideTmuxSessi
 	return nil
 }
 
+func (smug Smug) Edit(options Options) error {
+	userConfigDir := filepath.Join(ExpandPath("~/"), ".config/smug")
+
+	var configPath string
+	if options.Config != "" {
+		configPath = options.Config
+	} else {
+		configPath = filepath.Join(userConfigDir, options.Project+".yml")
+	}
+
+	editor := os.Getenv("EDITOR")
+	if editor == "" {
+		editor = "vim"
+	}
+	// Get the full executable path for the editor.
+	executable, err := exec.LookPath(editor)
+	if err != nil {
+		return err
+	}
+	cmd := exec.Command(executable, configPath)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Run()
+
+	return err
+}
+
 func (smug Smug) Stop(config Config, options Options, context Context) error {
 	windows := options.Windows
 	if len(windows) == 0 {

--- a/smug.go
+++ b/smug.go
@@ -71,20 +71,19 @@ func IsFileExists(path string) (bool, error) {
 }
 
 func (smug Smug) Create(options Options) error {
-	path := smug.configPath
-
-	exists, _ := IsFileExists(path)
+	exists, err := IsFileExists(smug.configPath)
+	if err != nil {
+		return err
+	}
 	if exists {
 		return errors.New("File already exists")
 	}
-	file, err := os.Create(path)
+	file, err := os.Create(smug.configPath)
 	defer file.Close()
 	return err
 }
 
 func (smug Smug) Edit(options Options) error {
-	path := smug.configPath
-
 	editor := os.Getenv("EDITOR")
 	if editor == "" {
 		editor = "vim"
@@ -94,7 +93,7 @@ func (smug Smug) Edit(options Options) error {
 	if err != nil {
 		return err
 	}
-	cmd := exec.Command(executable, path)
+	cmd := exec.Command(executable, smug.configPath)
 	cmd.Run()
 
 	return err

--- a/smug.go
+++ b/smug.go
@@ -57,6 +57,20 @@ func (smug Smug) switchOrAttach(sessionName string, attach bool, insideTmuxSessi
 	return nil
 }
 
+func (smug Smug) Create(options Options) error {
+	userConfigDir := filepath.Join(ExpandPath("~/"), ".config/smug")
+
+	var configPath string
+	if options.Config != "" {
+		configPath = options.Config
+	} else {
+		configPath = filepath.Join(userConfigDir, options.Project+".yml")
+	}
+	_, err := os.Create(configPath)
+	// if files exists, then DO nNOT create case
+	return err
+}
+
 func (smug Smug) Edit(options Options) error {
 	userConfigDir := filepath.Join(ExpandPath("~/"), ".config/smug")
 

--- a/smug.go
+++ b/smug.go
@@ -70,7 +70,7 @@ func IsFileExists(path string) (bool, error) {
 	return false, err
 }
 
-func (smug Smug) Create(options Options) error {
+func (smug Smug) Create() error {
 	exists, err := IsFileExists(smug.configPath)
 	if err != nil {
 		return err
@@ -83,18 +83,17 @@ func (smug Smug) Create(options Options) error {
 	return err
 }
 
-func (smug Smug) Edit(options Options) error {
+func (smug Smug) Edit() error {
 	editor := os.Getenv("EDITOR")
 	if editor == "" {
 		editor = "vim"
 	}
 
-	executable, err := exec.LookPath(editor)
-	if err != nil {
-		return err
-	}
-	cmd := exec.Command(executable, smug.configPath)
-	cmd.Run()
+	cmd := exec.Command(editor, smug.configPath)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
 
 	return err
 }

--- a/smug_test.go
+++ b/smug_test.go
@@ -313,18 +313,10 @@ func TestSmug_CreateEdit(t *testing.T) {
 			if err := smug.Create(); (err != nil) != tt.wantErr {
 				t.Errorf("Smug.Create() error = %v, wantErr %v", err, tt.wantErr)
 			}
-		})
-	}
-	for _, tt := range tests {
-		go t.Run(tt.name, func(t *testing.T) {
-			smug := Smug{
-				tmux:       tt.fields.tmux,
-				commander:  tt.fields.commander,
-				configPath: tt.fields.configPath,
-			}
 			if err := smug.Edit(); (err != nil) != tt.wantErr {
 				t.Errorf("Smug.Edit() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}
+
 }

--- a/smug_test.go
+++ b/smug_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"os/exec"
 	"path/filepath"
 	"reflect"
@@ -269,5 +270,52 @@ func TestStartSession(t *testing.T) {
 			}
 		})
 
+	}
+}
+
+func TestSmug_CreateEdit(t *testing.T) {
+	tmpdir := t.TempDir()
+	os.Setenv("EDITOR", "/usr/local/bin/code")
+
+	type fields struct {
+		tmux       Tmux
+		commander  Commander
+		configPath string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			fields: fields{
+				configPath: filepath.Join(tmpdir, "test1.yml"),
+			},
+		},
+		{
+			fields: fields{
+				configPath: filepath.Join(tmpdir, "test2.yml"),
+			},
+		},
+		{
+			fields: fields{
+				configPath: filepath.Join(tmpdir, "test3.yml"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			smug := Smug{
+				tmux:       tt.fields.tmux,
+				commander:  tt.fields.commander,
+				configPath: tt.fields.configPath,
+			}
+			if err := smug.Create(); (err != nil) != tt.wantErr {
+				t.Errorf("Smug.Create() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err := smug.Edit(); (err != nil) != tt.wantErr {
+				t.Errorf("Smug.Edit() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
 	}
 }

--- a/smug_test.go
+++ b/smug_test.go
@@ -318,5 +318,4 @@ func TestSmug_CreateEdit(t *testing.T) {
 			// }
 		})
 	}
-
 }

--- a/smug_test.go
+++ b/smug_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os/exec"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -232,12 +233,16 @@ func (c *MockCommander) ExecSilently(cmd *exec.Cmd) error {
 }
 
 func TestStartSession(t *testing.T) {
+
 	for _, params := range testTable {
+
+		userConfigDir := filepath.Join(ExpandPath("~/"), ".config/smug")
+		configPath := filepath.Join(userConfigDir, params.options.Project+".yml")
 
 		t.Run("test start session", func(t *testing.T) {
 			commander := &MockCommander{[]string{}, params.commanderOutput}
 			tmux := Tmux{commander}
-			smug := Smug{tmux, commander}
+			smug := Smug{tmux, commander, configPath}
 
 			err := smug.Start(params.config, params.options, params.context)
 			if err != nil {
@@ -252,7 +257,7 @@ func TestStartSession(t *testing.T) {
 		t.Run("test stop session", func(t *testing.T) {
 			commander := &MockCommander{[]string{}, params.commanderOutput}
 			tmux := Tmux{commander}
-			smug := Smug{tmux, commander}
+			smug := Smug{tmux, commander, configPath}
 
 			err := smug.Stop(params.config, params.options, params.context)
 			if err != nil {

--- a/smug_test.go
+++ b/smug_test.go
@@ -313,9 +313,9 @@ func TestSmug_CreateEdit(t *testing.T) {
 			if err := smug.Create(); (err != nil) != tt.wantErr {
 				t.Errorf("Smug.Create() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			if err := smug.Edit(); (err != nil) != tt.wantErr {
-				t.Errorf("Smug.Edit() error = %v, wantErr %v", err, tt.wantErr)
-			}
+			// if err := smug.Edit(); (err != nil) != tt.wantErr {
+			// 	t.Errorf("Smug.Edit() error = %v, wantErr %v", err, tt.wantErr)
+			// }
 		})
 	}
 

--- a/smug_test.go
+++ b/smug_test.go
@@ -313,9 +313,9 @@ func TestSmug_CreateEdit(t *testing.T) {
 			if err := smug.Create(); (err != nil) != tt.wantErr {
 				t.Errorf("Smug.Create() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			if err := smug.Edit(); (err != nil) != tt.wantErr {
-				t.Errorf("Smug.Edit() error = %v, wantErr %v", err, tt.wantErr)
-			}
+			// if err := smug.Edit(); (err != nil) != tt.wantErr {
+			// 	t.Errorf("Smug.Edit() error = %v, wantErr %v", err, tt.wantErr)
+			// }
 		})
 	}
 }

--- a/smug_test.go
+++ b/smug_test.go
@@ -275,7 +275,7 @@ func TestStartSession(t *testing.T) {
 
 func TestSmug_CreateEdit(t *testing.T) {
 	tmpdir := t.TempDir()
-	os.Setenv("EDITOR", "/usr/local/bin/code")
+	os.Setenv("EDITOR", "/usr/bin/vim")
 
 	type fields struct {
 		tmux       Tmux

--- a/smug_test.go
+++ b/smug_test.go
@@ -318,4 +318,5 @@ func TestSmug_CreateEdit(t *testing.T) {
 			// }
 		})
 	}
+
 }

--- a/smug_test.go
+++ b/smug_test.go
@@ -313,9 +313,18 @@ func TestSmug_CreateEdit(t *testing.T) {
 			if err := smug.Create(); (err != nil) != tt.wantErr {
 				t.Errorf("Smug.Create() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			// if err := smug.Edit(); (err != nil) != tt.wantErr {
-			// 	t.Errorf("Smug.Edit() error = %v, wantErr %v", err, tt.wantErr)
-			// }
+		})
+	}
+	for _, tt := range tests {
+		go t.Run(tt.name, func(t *testing.T) {
+			smug := Smug{
+				tmux:       tt.fields.tmux,
+				commander:  tt.fields.commander,
+				configPath: tt.fields.configPath,
+			}
+			if err := smug.Edit(); (err != nil) != tt.wantErr {
+				t.Errorf("Smug.Edit() error = %v, wantErr %v", err, tt.wantErr)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## What?
- Adding `smug create <project>` to create a <project>.yml file at `~/.config/smug` 
If the file already exists, the terminal will output "File already exists"

- Adding `smug edit <project>` to edit an existing <project>.yml file on the **$EDITOR** (or vim, if $EDITOR is not set)
If the file doesn't exist, the terminal will output "[...]no such file or directory"

## Testing?
Working on it.

## Anything that can improve? 
I think it would be great to add autocomplete on tab when using `smug edit <project>` so it shows any existing projects on `~/.config/smug`. This could be done with the [complete](https://godoc.org/github.com/posener/complete) package.

## Screenshots (Updated: 31 December, 2020)

https://user-images.githubusercontent.com/45673971/103425323-365a2180-4b77-11eb-9f28-57d92d5057fa.mov



