### PR TITLE
[bugfix] reference pane by id instead of index

### DIFF
--- a/smug.go
+++ b/smug.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 )
 
@@ -138,19 +137,19 @@ func (smug Smug) Start(config Config, options Options, context Context) error {
 			return err
 		}
 
-		for pIndex, p := range w.Panes {
+		for _, p := range w.Panes {
 			paneRoot := ExpandPath(p.Root)
 			if paneRoot == "" || !filepath.IsAbs(p.Root) {
 				paneRoot = filepath.Join(windowRoot, p.Root)
 			}
 
-			_, err := smug.tmux.SplitWindow(window, p.Type, paneRoot)
+			newPane, err := smug.tmux.SplitWindow(window, p.Type, paneRoot)
 			if err != nil {
 				return err
 			}
 
 			for _, c := range p.Commands {
-				err = smug.tmux.SendKeys(window+"."+strconv.Itoa(pIndex+1), c)
+				err = smug.tmux.SendKeys(window+"."+newPane, c)
 				if err != nil {
 					return err
 				}

--- a/smug_test.go
+++ b/smug_test.go
@@ -79,7 +79,7 @@ var testTable = []struct {
 			"tmux new -Pd -s ses -n smug_def -c root",
 			"tmux neww -Pd -t ses: -n win1 -c root",
 			"tmux select-layout -t ses:win1 main-horizontal",
-			"tmux split-window -Pd -t ses:win1 -c root -h",
+			"tmux split-window -Pd -t ses:win1 -c root -F #{pane_id} -h",
 			"tmux kill-window -t ses:smug_def",
 			"tmux move-window -r -s ses: -t ses:",
 			"tmux attach -d -t ses:win1",
@@ -89,7 +89,7 @@ var testTable = []struct {
 			"/bin/sh -c stop2 -d --foo=bar",
 			"tmux kill-session -t ses",
 		},
-		"xyz",
+		"1",
 	},
 	{
 		Config{
@@ -192,7 +192,7 @@ var testTable = []struct {
 			"tmux new -Pd -s ses -n smug_def -c root",
 			"tmux neww -Pd -t ses: -n win1 -c root/win1",
 			"tmux select-layout -t ses:win1 even-horizontal",
-			"tmux split-window -Pd -t ses:win1 -c root/win1/pane1 -v",
+			"tmux split-window -Pd -t ses:win1 -c root/win1/pane1 -F #{pane_id} -v",
 			"tmux send-keys -t ses:win1.1 command1 Enter",
 			"tmux kill-window -t ses:smug_def",
 			"tmux move-window -r -s ses: -t ses:",
@@ -201,7 +201,7 @@ var testTable = []struct {
 		[]string{
 			"tmux kill-session -t ses",
 		},
-		"xyz",
+		"1",
 	},
 	{
 		Config{

--- a/tmux.go
+++ b/tmux.go
@@ -67,7 +67,7 @@ func (tmux Tmux) RenumberWindows(target string) error {
 }
 
 func (tmux Tmux) SplitWindow(target string, splitType string, root string) (string, error) {
-	args := []string{"split-window", "-Pd", "-t", target, "-c", root}
+	args := []string{"split-window", "-Pd", "-t", target, "-c", root, "-F", "#{pane_id}"}
 
 	switch splitType {
 	case VSplit:


### PR DESCRIPTION
potential solution for #28 

We can utilize the -F [format] option of split-window to echo the pane id to stdout. We can then use the pane id directly to run the command rather than using the pane index from the config file.