### PR TITLE
Pass version via ldflags, trim GOPATH in stacktraces

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,6 +6,10 @@ before:
 builds:
   - env:
       - CGO_ENABLED=0
+    gcflags:
+      - "all=-trimpath={{.Env.GOPATH}}"
+    ldflags:
+     - "-X=main.version={{.Env.VERSION}}"
     goos:
       - linux
       - windows

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
-VERSION_REGEX  := 's/(v[0-9\.]+)/$(version)/g'
+VERSION = $(shell git describe --tags --abbrev=0)
+
+version:
+	@echo $(VERSION)
 
 build:
-	go build -o smug *.go
+	go build -ldflags "-X=main.version=$(VERSION)" -gcflags "all=-trimpath=$(GOPATH)"
 
 test:
-	go test .
+	go test
 
 coverage:
 	go test -coverprofile=coverage.out
@@ -14,8 +17,6 @@ release:
 ifndef GITHUB_TOKEN
 	$(error GITHUB_TOKEN is not defined)
 endif
-	sed -E -i.bak $(VERSION_REGEX) 'main.go' && rm main.go.bak
-	git commit -am 'Update version to $(version)'
 	git tag -a $(version) -m '$(version)'
 	git push origin $(version)
-	goreleaser --rm-dist
+	VERSION=$(version) goreleaser --rm-dist

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-const version = "v0.1.9"
+var version = "[dev build]"
 
 var usage = fmt.Sprintf(`Smug - tmux session manager. Version %s
 
@@ -43,7 +43,11 @@ func main() {
 	}
 
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Cannot parse command line options: %q", err.Error())
+		fmt.Fprintf(
+			os.Stderr,
+			"Cannot parse command line options: %q",
+			err.Error(),
+		)
 		os.Exit(1)
 	}
 
@@ -122,5 +126,4 @@ func main() {
 
 		fmt.Println(strings.Join(configs, "\n"))
 	}
-
 }


### PR DESCRIPTION
This way you can avoid unnecessary commits and unnecessary build info.