### PR TITLE
make documentation complete

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,6 +24,12 @@ Options:
 	-a, --attach %s
 	-d, --debug %s
 
+Commands:
+	list    list available project sessions
+	start   start project session
+	stop    stop project session
+	print   session configuration to stdout
+
 Examples:
 	$ smug list
 	$ smug start blog

--- a/man/man1/smug.1
+++ b/man/man1/smug.1
@@ -21,7 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ..
-.TH smug 1 "Mar 2021" "smug 0.1.9" "smug - a session manager for tmux written in go"
+.TH smug 1 "Mar 2021" "smug 0.2.0" "smug - a session manager for tmux written in go"
 
 .SH NAME
 smug - a session manager for tmux written in go
@@ -64,6 +64,10 @@ Force switch client for a session.
 .B "stop [<projectname>]"
 Stop tmux project session
 
+.TP
+.B "print"
+Print current session configuration as yaml to stdout
+
 .SH EXAMPLES
 $ smug list
 .br
@@ -78,6 +82,8 @@ $ smug start blog:win1,win2
 $ smug stop blog
 .br
 $ smug start blog --attach
+.br
+$ smug print > ~/.config/smug/new_project.yml
 
 .SH AUTHOR
 Ivan Klymenchenko


### PR DESCRIPTION
Add print command and improve usage...

```
Usage:
        smug <command> [<project>] [-f, --file <file>] [-w, --windows <window>]... [-a, --attach] [-d, --debug]

Options:
        -f, --file A custom path to a config file
        -w, --windows List of windows to start. If session exists, those windows will be attached to current session.
        -a, --attach Force switch client for a session
        -d, --debug Print all commands to ~/.config/smug/smug.log

Commands:
        list    list available project sessions
        start   start project session
        stop    stop project session
        print   session configuration to stdout

Examples:
        $ smug list
        $ smug start blog
        $ smug start blog:win1
        $ smug start blog -w win1
        $ smug start blog:win1,win2
        $ smug stop blog
        $ smug start blog --attach
```