### PR TITLE
README: add MacPorts instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ cd smug
 go install
 ```
 
+### MacPorts (macOS)
+
+On macOS, you can install Smug using [MacPorts](https://www.macports.org).  Once MacPorts is installed, simply issue the following commands:
+
+```bash
+sudo port selfupdate
+sudo port install smug
+```
+
 ## Usage
 
 ```


### PR DESCRIPTION
Just adding instructions on how to install Smug on macOS with MacPorts.