### PR TITLE
initial implementation of stop-within-session without name

### DIFF
--- a/config.go
+++ b/config.go
@@ -58,10 +58,10 @@ func GetConfig(path string, settings map[string]string) (Config, error) {
 
 	config := string(f)
 
-	return ParseConfig(config, settings)
+	return ParseConfig(config, settings, path)
 }
 
-func ParseConfig(data string, settings map[string]string) (Config, error) {
+func ParseConfig(data string, settings map[string]string, path string) (Config, error) {
 	data = os.Expand(data, func(v string) string {
 		if val, ok := settings[v]; ok {
 			return val
@@ -81,7 +81,17 @@ func ParseConfig(data string, settings map[string]string) (Config, error) {
 		return Config{}, err
 	}
 
+	AddDefaultEnvs(&c, path)
+
 	return c, nil
+}
+
+func AddDefaultEnvs(c *Config, path string) {
+
+	c.Env["SMUG_SESSION"] = "true"
+	c.Env["SMUG_SESSION_NAME"] = c.Session
+	c.Env["SMUG_SESSION_CONFIG_PATH"] = path
+
 }
 
 func ListConfigs(dir string) ([]string, error) {

--- a/options.go
+++ b/options.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"errors"
-	"strings"
-
 	"github.com/spf13/pflag"
+	"os"
+	"strings"
 )
 
 const (
@@ -133,6 +133,11 @@ func ParseOptions(argv []string, helpRequested func()) (Options, error) {
 
 	if err != nil {
 		return Options{}, err
+	}
+
+	// If config file flag is not set, and env is, use the env
+	if len(*config) == 0 && len(os.Getenv("SMUG_SESSION_CONFIG_PATH")) > 0 {
+		*config = os.Getenv("SMUG_SESSION_CONFIG_PATH")
 	}
 
 	var project string


### PR DESCRIPTION
This PR closes #84.

It accomplishes this with two main changes:

## Env Vars

It adds three env vars to all smug-created tmux sessions.

- `$SMUG_SESSION` - always equal to "true". Allows users to do easier scripting and detection if it's a smug-managed session
- `$SMUG_SESSION_NAME` - name of the tmux session smug created
- `$SMUG_SESSION_CONFIG_PATH` - full filepath of the smug config file that created this session

## Config parser

If the `--file` arg is not specified, but `$SMUG_SESSION_CONFIG_PATH` is set, the value of the env var is put into the `--file` value variable, allowing all normal commands that would work with `--file` manually specified to work automatically within a smug session. This lets smug be aware of it's current context if existing within a smug session, and operate on it by default unless you force it to do something else. For example, `smug stop` or `smug edit` work without any additional args.
