### PR TITLE
set a custom timeout before executing send-keys for commands

### DIFF
--- a/config.go
+++ b/config.go
@@ -27,12 +27,13 @@ type Window struct {
 }
 
 type Config struct {
-	Session     string            `yaml:"session"`
-	Env         map[string]string `yaml:"env"`
-	Root        string            `yaml:"root"`
-	BeforeStart []string          `yaml:"before_start"`
-	Stop        []string          `yaml:"stop"`
-	Windows     []Window          `yaml:"windows"`
+	SendKeysTimeout int               `yaml:"sendkeys_timeout"`
+	Session         string            `yaml:"session"`
+	Env             map[string]string `yaml:"env"`
+	Root            string            `yaml:"root"`
+	BeforeStart     []string          `yaml:"before_start"`
+	Stop            []string          `yaml:"stop"`
+	Windows         []Window          `yaml:"windows"`
 }
 
 func addDefaultEnvs(c *Config, path string) {

--- a/config_test.go
+++ b/config_test.go
@@ -9,6 +9,7 @@ import (
 func TestParseConfig(t *testing.T) {
 	yaml := `
 session: ${session}
+sendkeys_timeout: 200
 windows:
   - layout: tiled
     commands:
@@ -27,8 +28,9 @@ windows:
 	}
 
 	expected := Config{
-		Session: "test",
-		Env:     make(map[string]string),
+		Session:         "test",
+		SendKeysTimeout: 200,
+		Env:             make(map[string]string),
 		Windows: []Window{
 			{
 				Layout:   "tiled",

--- a/smug.go
+++ b/smug.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 const defaultWindowName = "smug_def"
@@ -153,6 +154,7 @@ func (smug Smug) Start(config *Config, options *Options, context Context) error 
 		}
 
 		for _, c := range w.Commands {
+			time.Sleep(time.Millisecond * time.Duration(config.SendKeysTimeout))
 			err := smug.tmux.SendKeys(window, c)
 			if err != nil {
 				return err
@@ -180,6 +182,7 @@ func (smug Smug) Start(config *Config, options *Options, context Context) error 
 			}
 
 			for _, c := range p.Commands {
+				time.Sleep(time.Millisecond * time.Duration(config.SendKeysTimeout))
 				err = smug.tmux.SendKeys(window+"."+newPane, c)
 				if err != nil {
 					return err


### PR DESCRIPTION
  In some situations send-keys might fire before the shell prompt finished initilization. It happened for me when using fish shell and *oh-my-fish* which makes the send-keys start executing bofore my shell is ready and I endup with a written command that is not executed

  This patch adds a custom `sendkeys_timeout` as a top level option that takes an integer in milliseconds. It will ensure a Sleep call is made before.