### PR TITLE
chore(goreleaser): fix asset names

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,7 +15,7 @@ archives:
   - format: tar.gz
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
-      "smug {{  .Version }}"_
+      smug_{{  .Version }}_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386


### PR DESCRIPTION
Remove quotes and a space from asset names.

## Issue to solve

Asset names include quotes and a space.

```console
$ goreleaser release --snapshot
  • skipping announce, publish and validate...
  • loading environment variables
  • getting and validating git state
    • git state                                      commit=f0ea4942e0d73a64f9f10b04eb7b0531f398e441 branch=master current_tag=v0.3.5 previous_tag=v0.3.4 dirty=false
    • pipe skipped                                   reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
  • snapshotting
    • building snapshot...                           version=v0.3.5-next
  • running before hooks
    • running                                        hook=go mod download
  • ensuring distribution directory
  • setting up metadata
  • writing release metadata
  • loading go mod information
  • build prerequisites
  • building binaries
    • building                                       binary=dist/smug_darwin_arm64/smug
    • building                                       binary=dist/smug_windows_arm64/smug.exe
    • building                                       binary=dist/smug_windows_386/smug.exe
    • building                                       binary=dist/smug_linux_arm64/smug
    • building                                       binary=dist/smug_linux_amd64_v1/smug
    • building                                       binary=dist/smug_linux_386/smug
    • building                                       binary=dist/smug_darwin_amd64_v1/smug
    • building                                       binary=dist/smug_windows_amd64_v1/smug.exe
  • archives
    • creating                                       archive=dist/"smug v0.3.5-next"_Linux_x86_64.tar.gz
    • creating                                       archive=dist/"smug v0.3.5-next"_Darwin_arm64.tar.gz
    • creating                                       archive=dist/"smug v0.3.5-next"_Windows_x86_64.zip
    • creating                                       archive=dist/"smug v0.3.5-next"_Linux_i386.tar.gz
    • creating                                       archive=dist/"smug v0.3.5-next"_Darwin_x86_64.tar.gz
    • creating                                       archive=dist/"smug v0.3.5-next"_Linux_arm64.tar.gz
    • creating                                       archive=dist/"smug v0.3.5-next"_Windows_arm64.zip
    • creating                                       archive=dist/"smug v0.3.5-next"_Windows_i386.zip
  • linux packages
    • creating                                       package=smug format=rpm arch=arm64 file=dist/smug_v0.3.5-next_linux_arm64.rpm
    • creating                                       package=smug format=deb arch=amd64v1 file=dist/smug_v0.3.5-next_linux_amd64.deb
    • creating                                       package=smug format=rpm arch=amd64v1 file=dist/smug_v0.3.5-next_linux_amd64.rpm
    • creating                                       package=smug format=rpm arch=386 file=dist/smug_v0.3.5-next_linux_386.rpm
    • creating                                       package=smug format=deb arch=386 file=dist/smug_v0.3.5-next_linux_386.deb
    • creating                                       package=smug format=deb arch=arm64 file=dist/smug_v0.3.5-next_linux_arm64.deb
  • calculating checksums
  • writing artifacts metadata
  • release succeeded after 6s
  • thanks for using goreleaser!
```

```console
$ ls dist 
'"smug v0.3.5-next"_Darwin_arm64.tar.gz'    checksums.txt                    smug_v0.3.5-next_linux_386.rpm
'"smug v0.3.5-next"_Darwin_x86_64.tar.gz'   config.yaml                      smug_v0.3.5-next_linux_amd64.deb
'"smug v0.3.5-next"_Linux_arm64.tar.gz'     metadata.json                    smug_v0.3.5-next_linux_amd64.rpm
'"smug v0.3.5-next"_Linux_i386.tar.gz'      smug_darwin_amd64_v1             smug_v0.3.5-next_linux_arm64.deb
'"smug v0.3.5-next"_Linux_x86_64.tar.gz'    smug_darwin_arm64                smug_v0.3.5-next_linux_arm64.rpm
'"smug v0.3.5-next"_Windows_arm64.zip'      smug_linux_386                   smug_windows_386
'"smug v0.3.5-next"_Windows_i386.zip'       smug_linux_amd64_v1              smug_windows_amd64_v1
'"smug v0.3.5-next"_Windows_x86_64.zip'     smug_linux_arm64                 smug_windows_arm64
 artifacts.json                             smug_v0.3.5-next_linux_386.deb
```

GitHub removes quotes and converts a space into a period.

https://github.com/ivaaaan/smug/releases/tag/v0.3.5

<img width="1194" alt="image" src="https://github.com/user-attachments/assets/89d20fc4-2dac-4b05-bc25-f177ef91c43e">

```console
$ gh release -R ivaaaan/smug view v0.3.5
v0.3.5
github-actions[bot] released this about 12 hours ago

  ## Changelog                                                                                                        
                                                                                                                      
  • a4a05e8a62410c3cdee726f2f8d4bb894dd6ff26 Feature/allow to group projects dirs issue #89 (#127)                    


Assets
checksums.txt                     1.30 KiB
smug.0.3.5._Darwin_arm64.tar.gz   1.10 MiB
smug.0.3.5._Darwin_x86_64.tar.gz  1.16 MiB
smug.0.3.5._Linux_arm64.tar.gz    1.07 MiB
smug.0.3.5._Linux_i386.tar.gz     1.10 MiB
smug.0.3.5._Linux_x86_64.tar.gz   1.15 MiB
smug.0.3.5._Windows_arm64.zip     1.10 MiB
smug.0.3.5._Windows_i386.zip      1.16 MiB
smug.0.3.5._Windows_x86_64.zip    1.20 MiB
smug_0.3.5_linux_386.deb          1.10 MiB
smug_0.3.5_linux_386.rpm          1.13 MiB
smug_0.3.5_linux_amd64.deb        1.15 MiB
smug_0.3.5_linux_amd64.rpm        1.19 MiB
smug_0.3.5_linux_arm64.deb        1.08 MiB
smug_0.3.5_linux_arm64.rpm        1.10 MiB
```

## Test

I've confirmed the issue would be solved.

```console
$ goreleaser release --snapshot --clean           
  • skipping announce, publish and validate...
  • cleaning distribution directory
  • loading environment variables
  • getting and validating git state
    • git state                                      commit=f0ea4942e0d73a64f9f10b04eb7b0531f398e441 branch=master current_tag=v0.3.5 previous_tag=v0.3.4 dirty=true
    • pipe skipped                                   reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
  • snapshotting
    • building snapshot...                           version=v0.3.5-next
  • running before hooks
    • running                                        hook=go mod download
  • ensuring distribution directory
  • setting up metadata
  • writing release metadata
  • loading go mod information
  • build prerequisites
  • building binaries
    • building                                       binary=dist/smug_darwin_arm64/smug
    • building                                       binary=dist/smug_windows_386/smug.exe
    • building                                       binary=dist/smug_darwin_amd64_v1/smug
    • building                                       binary=dist/smug_linux_amd64_v1/smug
    • building                                       binary=dist/smug_windows_amd64_v1/smug.exe
    • building                                       binary=dist/smug_linux_arm64/smug
    • building                                       binary=dist/smug_windows_arm64/smug.exe
    • building                                       binary=dist/smug_linux_386/smug
  • archives
    • creating                                       archive=dist/smug_v0.3.5-next_Windows_arm64.zip
    • creating                                       archive=dist/smug_v0.3.5-next_Darwin_arm64.tar.gz
    • creating                                       archive=dist/smug_v0.3.5-next_Linux_i386.tar.gz
    • creating                                       archive=dist/smug_v0.3.5-next_Windows_i386.zip
    • creating                                       archive=dist/smug_v0.3.5-next_Linux_x86_64.tar.gz
    • creating                                       archive=dist/smug_v0.3.5-next_Linux_arm64.tar.gz
    • creating                                       archive=dist/smug_v0.3.5-next_Darwin_x86_64.tar.gz
    • creating                                       archive=dist/smug_v0.3.5-next_Windows_x86_64.zip
  • linux packages
    • creating                                       package=smug format=deb arch=amd64v1 file=dist/smug_v0.3.5-next_linux_amd64.deb
    • creating                                       package=smug format=deb arch=386 file=dist/smug_v0.3.5-next_linux_386.deb
    • creating                                       package=smug format=rpm arch=386 file=dist/smug_v0.3.5-next_linux_386.rpm
    • creating                                       package=smug format=deb arch=arm64 file=dist/smug_v0.3.5-next_linux_arm64.deb
    • creating                                       package=smug format=rpm arch=amd64v1 file=dist/smug_v0.3.5-next_linux_amd64.rpm
    • creating                                       package=smug format=rpm arch=arm64 file=dist/smug_v0.3.5-next_linux_arm64.rpm
  • calculating checksums
  • writing artifacts metadata
  • release succeeded after 3s
  • thanks for using goreleaser!
```

```console
$ ls dist 
artifacts.json        smug_linux_amd64_v1                    smug_v0.3.5-next_Windows_arm64.zip   smug_v0.3.5-next_linux_arm64.deb
checksums.txt         smug_linux_arm64                       smug_v0.3.5-next_Windows_i386.zip    smug_v0.3.5-next_linux_arm64.rpm
config.yaml           smug_v0.3.5-next_Darwin_arm64.tar.gz   smug_v0.3.5-next_Windows_x86_64.zip  smug_windows_386
metadata.json         smug_v0.3.5-next_Darwin_x86_64.tar.gz  smug_v0.3.5-next_linux_386.deb       smug_windows_amd64_v1
smug_darwin_amd64_v1  smug_v0.3.5-next_Linux_arm64.tar.gz    smug_v0.3.5-next_linux_386.rpm       smug_windows_arm64
smug_darwin_arm64     smug_v0.3.5-next_Linux_i386.tar.gz     smug_v0.3.5-next_linux_amd64.deb
smug_linux_386        smug_v0.3.5-next_Linux_x86_64.tar.gz   smug_v0.3.5-next_linux_amd64.rpm
```