### PR TITLE
Prevent overriding detach flag if selected

### DIFF
--- a/main.go
+++ b/main.go
@@ -143,7 +143,7 @@ func main() {
 				os.Exit(1)
 			}
 
-			options.Detach = configIndex != len(configs)-1
+			options.Detach = options.Detach || (configIndex != len(configs)-1)
 
 			err = smug.Start(config, options, context)
 			if err != nil {


### PR DESCRIPTION
The detach flag gets flipped to false forcibly for the last config called on the command line. This simply respects the flag if set on the command line.

Currently the last config is attached no matter the addition of the --detach flag to the command call