### PR TITLE
feat: add attach config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,10 @@ xyz@localhost:~$ smug start -f ./project.yml -w window1 -w window2
 Configuration files can stored in the `~/.config/smug` directory in the `YAML` format, e.g `~/.config/smug/your_project.yml`.
 You may also create a file named `.smug.yml` in the current working directory, which will be used by default.
 
+### Session-level options
+
+- `attach` - Automatically attach to the session after creation (defaults to `false`). The `-a` flag can also enable attachment.
+
 ### Examples
 
 #### Example 1
@@ -199,6 +203,7 @@ windows:
 
 ```yaml
 session: blog
+attach: true # Automatically attach to this session
 
 root: ~/Code/blog
 

--- a/config.go
+++ b/config.go
@@ -39,8 +39,9 @@ type Window struct {
 }
 
 type Config struct {
-	SendKeysTimeout int    `yaml:"sendkeys_timeout"`
-	Session         string `yaml:"session"`
+	SendKeysTimeout int               `yaml:"sendkeys_timeout"`
+	Session         string            `yaml:"session"`
+	Attach          bool              `yaml:"attach,omitempty"`
 	TmuxOptions     `yaml:"tmux_options"`
 	Env             map[string]string `yaml:"env"`
 	Root            string            `yaml:"root"`

--- a/config.go
+++ b/config.go
@@ -39,10 +39,12 @@ type Window struct {
 }
 
 type Config struct {
-	SendKeysTimeout int               `yaml:"sendkeys_timeout"`
-	Session         string            `yaml:"session"`
-	Attach          bool              `yaml:"attach,omitempty"`
-	TmuxOptions     `yaml:"tmux_options"`
+	SendKeysTimeout int    `yaml:"sendkeys_timeout"`
+	Session         string `yaml:"session"`
+	// Attach controls whether the session automatically attaches after creation.
+	// The -a/--attach CLI flag can also enable attachment.
+	Attach      bool              `yaml:"attach,omitempty"`
+	TmuxOptions `yaml:"tmux_options"`
 	Env             map[string]string `yaml:"env"`
 	Root            string            `yaml:"root"`
 	BeforeStart     []string          `yaml:"before_start"`

--- a/config_test.go
+++ b/config_test.go
@@ -58,3 +58,40 @@ windows:
 		t.Fatalf("expected %v, got %v", expected, config)
 	}
 }
+
+func TestParseConfigWithAttach(t *testing.T) {
+	yaml := `
+session: test
+attach: true
+windows:
+  - name: editor
+    commands:
+      - vim`
+
+	config, err := ParseConfig(yaml, map[string]string{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !config.Attach {
+		t.Fatal("expected attach to be true, got false")
+	}
+}
+
+func TestParseConfigWithoutAttach(t *testing.T) {
+	yaml := `
+session: test
+windows:
+  - name: editor
+    commands:
+      - vim`
+
+	config, err := ParseConfig(yaml, map[string]string{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if config.Attach {
+		t.Fatal("expected attach to be false by default, got true")
+	}
+}

--- a/smug.go
+++ b/smug.go
@@ -108,7 +108,7 @@ func (smug Smug) Start(config *Config, options *Options, context Context) error 
 	sessionExists := smug.tmux.SessionExists(sessionName)
 	sessionRoot := ExpandPath(config.Root)
 	windows := options.Windows
-	attach := options.Attach
+	attach := options.Attach || config.Attach
 
 	if !sessionExists && !createWindowsInsideCurrSession {
 		err := smug.execShellCommands(config.BeforeStart, sessionRoot)


### PR DESCRIPTION
## Problem

When managing multiple projects, some sessions should auto-attach while others should start detached. Currently, there's no way to configure this behavior per-project in the YAML file.

## Solution

Added an optional `attach` field to the configuration:

```yaml
session: my-project
attach: true

windows:
  - name: editor
    commands:
      - vim
```

**Changes:**
- Added `Attach bool` field to `Config` struct
- Modified logic to use `options.Attach || config.Attach`
- Added tests and documentation

**Backward compatible:** The `-a` flag continues to work, and existing configs without `attach` default to `false`.