### PR TITLE
Adding 'rm' command to delete projects

### DIFF
--- a/completion/smug.bash
+++ b/completion/smug.bash
@@ -9,19 +9,19 @@ _smug() {
     # if command is 'list' or 'print' do not suggest more
     for word in ${COMP_WORDS[@]}; do
         case $word in
-            list|print) return
+            list|print|rm) return
         esac
     done
 
     # commands
     if (( "${#COMP_WORDS[@]}" == 2 )); then
-        reply=($(compgen -W "list print start stop" -- "${cur}"))
+        reply=($(compgen -W "list print rm start stop" -- "${cur}"))
     fi
 
     # projects
     if (( "${#COMP_WORDS[@]}" == 3 )); then
         case ${prev} in
-            start|stop)
+            start|stop|rm)
                 reply=($(compgen -W "$(smug list | grep -F -v smug)" -- "${cur}"))
         esac
     fi

--- a/completion/smug.fish
+++ b/completion/smug.fish
@@ -1,1 +1,2 @@
 complete -x -c smug -a "(ls ~/.config/smug | grep -v \"smug\.log\" | sed -e 's/\..*//')"
+complete -c smug -n '__fish_use_subcommand' -a 'rm' -d 'Remove project configuration'

--- a/config.go
+++ b/config.go
@@ -57,6 +57,10 @@ func addDefaultEnvs(c *Config, path string) {
 	c.Env["SMUG_SESSION_CONFIG_PATH"] = path
 }
 
+func RemoveConfig(path string) error {
+	return os.Remove(path)
+}
+
 func EditConfig(path string) error {
 	editor := os.Getenv("EDITOR")
 	if editor == "" {

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
 	"log"
@@ -35,6 +36,7 @@ Commands:
 	start   start project session
 	stop    stop project session
 	print   session configuration to stdout
+	rm      remove project configuration
 
 Examples:
 	$ smug list
@@ -47,6 +49,7 @@ Examples:
 	$ smug stop blog
 	$ smug start blog --attach
 	$ smug print > ~/.config/smug/blog.yml
+	$ smug rm blog
 `, version, FileUsage, WindowsUsage, AttachUsage, InsideCurrentSessionUsage, DebugUsage, DetachUsage)
 
 const (
@@ -210,6 +213,26 @@ func main() {
 
 		}
 
+	case CommandRemove:
+		config, err := FindConfig(userConfigDir, options.Project)
+		if err != nil {
+			fmt.Fprint(os.Stderr, err.Error())
+			os.Exit(1)
+		}
+
+		fmt.Printf("You are gonna delete %s, are you sure? [y/N]: ", options.Project)
+		scanner := bufio.NewScanner(os.Stdin)
+		scanner.Scan()
+		if strings.ToLower(strings.TrimSpace(scanner.Text())) != "y" {
+			return
+		}
+
+		err = RemoveConfig(filepath.Join(userConfigDir, config))
+		if err != nil {
+			fmt.Fprint(os.Stderr, err.Error())
+			os.Exit(1)
+		}
+		fmt.Println("Removed " + options.Project)
 	case CommandPrint:
 		config, err := smug.GetConfigFromSession(options, context)
 		if err != nil {

--- a/man/man1/smug.1
+++ b/man/man1/smug.1
@@ -65,6 +65,10 @@ Force switch client for a session.
 Stop tmux project session
 
 .TP
+.B "rm [<projectname>]"
+Remove a project configuration. Asks for confirmation before deleting.
+
+.TP
 .B "print"
 Print current session configuration as yaml to stdout
 
@@ -84,6 +88,8 @@ $ smug stop blog
 $ smug start blog --attach
 .br
 $ smug print > ~/.config/smug/new_project.yml
+.br
+$ smug rm blog
 
 .SH AUTHOR
 Ivan Klymenchenko

--- a/options.go
+++ b/options.go
@@ -10,12 +10,13 @@ import (
 )
 
 const (
-	CommandStart = "start"
-	CommandStop  = "stop"
-	CommandNew   = "new"
-	CommandEdit  = "edit"
-	CommandList  = "list"
-	CommandPrint = "print"
+	CommandStart  = "start"
+	CommandStop   = "stop"
+	CommandNew    = "new"
+	CommandEdit   = "edit"
+	CommandList   = "list"
+	CommandPrint  = "print"
+	CommandRemove = "rm"
 )
 
 type command struct {
@@ -49,6 +50,10 @@ var Commands = commands{
 	{
 		Name:    CommandPrint,
 		Aliases: []string{"p"},
+	},
+	{
+		Name:    CommandRemove,
+		Aliases: []string{"r"},
 	},
 }
 

--- a/options_test.go
+++ b/options_test.go
@@ -232,6 +232,17 @@ var usageTestTable = []struct {
 		errors.New("unknown flag: --test"),
 		nil,
 	},
+	{
+		[]string{"rm", "blog"},
+		Options{
+			Command:  "rm",
+			Project:  "blog",
+			Windows:  []string{},
+			Settings: map[string]string{},
+		},
+		nil,
+		nil,
+	},
 }
 
 func TestParseOptions(t *testing.T) {


### PR DESCRIPTION
I like `smug` but I don't like to delete the project files using `rm` command, I think it's much easier if `smug` simplify this for us.

So, this add a `smug rm <project>` command to delete config files easily from `~/.config/smug/`
  - Always ask for confirmation (`You are gonna delete <project>, are you sure? [y/N]:`)
  - Alias: `smug r <project>`
  - Tests passed (`options_test.go`)