### PR TITLE
fix: #149 - Generate the right number of panes

### DIFF
--- a/smug.go
+++ b/smug.go
@@ -249,7 +249,7 @@ func (smug Smug) GetConfigFromSession(options *Options, context Context) (Config
 		}
 
 		panes := []Pane{}
-		for _, p := range tmuxPanes {
+		for _, p := range tmuxPanes[1:] {
 			root := p.Root
 			if root == w.Root {
 				root = ""

--- a/smug_test.go
+++ b/smug_test.go
@@ -332,7 +332,6 @@ func TestPrintCurrentSession(t *testing.T) {
 				Root:   "root",
 				Layout: "layout",
 				Panes: []Pane{
-					{},
 					{
 						Root: "/tmp",
 					},


### PR DESCRIPTION
Whole evidence and full explanation of the issue is in #149 

`smug print` captures all panes per window, but `smug start` already creates one pane via `NewWindow()` before iterating the panes list and calling `SplitWindow()` for each. Then we have N+1 panes instead of N, causing the layout to fail

So the fix is siple, skipping the first pane fixes the off-by-one
A window with `3` tmux panes now produces `2` pane entries → `NewWindow (1) + 2 splits = 3 panes`


- Not working layout generated by `smug pring`
  ```
  sendkeys_timeout: 0
  session: test
  tmux_options:
    socket_name: ""
    socket_path: ""
    config_file: ""
  env: {}
  root: ""
  before_start: []
  stop: []
  windows:
  - selected: false
    name: w1
    root: /Users/XXXX
    before_start: []
    panes:
    - commands: []
    commands: []
    layout: 3103,214x55,0,0,303
  - selected: false
    name: w2
    root: /Users/XXXX/Documents
    before_start: []
    panes:
    - commands: []
    - commands: []
    commands: []
    layout: f355,214x55,0,0{106x55,0,0,304,107x55,107,0,310}
  - selected: false
    name: w3
    root: /Users/XXXX/Downloads
    before_start: []
    panes:
    - commands: []
    - commands: []
    - commands: []
    commands: []
    layout: 35c0,214x55,0,0[214x18,0,0,312,214x18,0,19,313,214x17,0,38,314]
  - selected: false
    name: w4
    root: /Users/XXXX/Pictures
    before_start: []
    panes:
    - commands: []
    - commands: []
    - commands: []
    - commands: []
    commands: []
    layout: 8350,214x55,0,0[214x27,0,0{106x27,0,0,306,107x27,107,0,309},214x27,0,28{106x27,0,28,307,107x27,107,28,308}]
  ```

- Fixed layout :
  ```
  sendkeys_timeout: 0
  session: X
  tmux_options:
    socket_name: ""
    socket_path: ""
    config_file: ""
  env: {}
  root: ""
  before_start: []
  stop: []
  windows:
  - selected: false
    name: w1
    root: /Users/XXXX/workspace/dev/smug
    before_start: []
    panes: []
    commands: []
    layout: 3103,214x55,0,0,303
  - selected: false
    name: w2
    root: /Users/XXXX/Documents
    before_start: []
    panes:
    - commands: []
    commands: []
    layout: f355,214x55,0,0{106x55,0,0,304,107x55,107,0,310}
  - selected: false
    name: w3
    root: /Users/XXXX/Downloads
    before_start: []
    panes:
    - commands: []
    - commands: []
    commands: []
    layout: 35c0,214x55,0,0[214x18,0,0,312,214x18,0,19,313,214x17,0,38,314]
  - selected: false
    name: w4
    root: /Users/XXXX/Pictures
    before_start: []
    panes:
    - commands: []
    - commands: []
    - commands: []
    commands: []
    layout: 8350,214x55,0,0[214x27,0,0{106x27,0,0,306,107x27,107,0,309},214x27,0,28{106x27,0,28,307,107x27,107,28,308}]
  ```