### PR TITLE
Fix #80, fixes conflicts with prefixed names

### DIFF
--- a/smug_test.go
+++ b/smug_test.go
@@ -31,7 +31,7 @@ var testTable = map[string]struct {
 		&Options{},
 		Context{},
 		[]string{
-			"tmux has-session -t ses:",
+			"tmux list-sessions -F #{session_name}",
 			"/bin/sh -c command1",
 			"/bin/sh -c command2",
 			"tmux new -Pd -s ses -n smug_def -c smug/root",
@@ -45,7 +45,7 @@ var testTable = map[string]struct {
 		[]string{
 			"tmux kill-session -t ses",
 		},
-		[]string{"ses", "win1"},
+		[]string{"", "win1"},
 	},
 	"test with 1 window and Detach: true": {
 		&Config{
@@ -63,7 +63,7 @@ var testTable = map[string]struct {
 		},
 		Context{},
 		[]string{
-			"tmux has-session -t ses:",
+			"tmux list-sessions -F #{session_name}",
 			"/bin/sh -c command1",
 			"/bin/sh -c command2",
 			"tmux new -Pd -s ses -n smug_def -c root",
@@ -107,7 +107,7 @@ var testTable = map[string]struct {
 		&Options{},
 		Context{},
 		[]string{
-			"tmux has-session -t ses:",
+			"tmux list-sessions -F #{session_name}",
 			"tmux new -Pd -s ses -n smug_def -c root",
 			"tmux neww -Pd -t ses: -c root -F #{window_id} -n win1",
 			"tmux split-window -Pd -h -t win1 -c root -F #{pane_id}",
@@ -123,7 +123,7 @@ var testTable = map[string]struct {
 			"/bin/sh -c stop2 -d --foo=bar",
 			"tmux kill-session -t ses",
 		},
-		[]string{"ses", "ses", "win1", "1"},
+		[]string{"", "ses", "win1", "1"},
 	},
 	"test start windows from option's Windows parameter": {
 		&Config{
@@ -145,7 +145,7 @@ var testTable = map[string]struct {
 		},
 		Context{},
 		[]string{
-			"tmux has-session -t ses:",
+			"tmux list-sessions -F #{session_name}",
 			"tmux new -Pd -s ses -n smug_def -c root",
 			"tmux neww -Pd -t ses: -c root -F #{window_id} -n win2",
 			"tmux select-layout -t xyz even-horizontal",
@@ -169,13 +169,13 @@ var testTable = map[string]struct {
 		&Options{},
 		Context{},
 		[]string{
-			"tmux has-session -t ses:",
+			"tmux list-sessions -F #{session_name}",
 			"tmux attach -d -t ses:",
 		},
 		[]string{
 			"tmux kill-session -t ses",
 		},
-		[]string{""},
+		[]string{"ses"},
 	},
 	"test start a new session from another tmux session": {
 		&Config{
@@ -185,7 +185,7 @@ var testTable = map[string]struct {
 		&Options{Attach: false},
 		Context{InsideTmuxSession: true},
 		[]string{
-			"tmux has-session -t ses:",
+			"tmux list-sessions -F #{session_name}",
 			"tmux new -Pd -s ses -n smug_def -c root",
 			"tmux kill-window -t ses:smug_def",
 			"tmux move-window -r -s ses: -t ses:",
@@ -206,13 +206,13 @@ var testTable = map[string]struct {
 		&Options{Attach: true},
 		Context{InsideTmuxSession: true},
 		[]string{
-			"tmux has-session -t ses:",
+			"tmux list-sessions -F #{session_name}",
 			"tmux switch-client -t ses:",
 		},
 		[]string{
 			"tmux kill-session -t ses",
 		},
-		[]string{""},
+		[]string{"ses"},
 	},
 	"test create new windows in current session with same name": {
 		&Config{
@@ -228,7 +228,7 @@ var testTable = map[string]struct {
 		Context{InsideTmuxSession: true},
 		[]string{
 			"tmux display-message -p #S",
-			"tmux has-session -t ses:",
+			"tmux list-sessions -F #{session_name}",
 			"tmux neww -Pd -t ses: -c root -F #{window_id} -n win1",
 			"tmux select-layout -t  even-horizontal",
 		},
@@ -251,7 +251,7 @@ var testTable = map[string]struct {
 		Context{InsideTmuxSession: true},
 		[]string{
 			"tmux display-message -p #S",
-			"tmux has-session -t ses:",
+			"tmux list-sessions -F #{session_name}",
 			"tmux neww -Pd -t ses: -c root -F #{window_id} -n win1",
 			"tmux select-layout -t win1 even-horizontal",
 		},

--- a/tmux.go
+++ b/tmux.go
@@ -66,9 +66,19 @@ func (tmux Tmux) NewSession(name string, root string, windowName string) (string
 }
 
 func (tmux Tmux) SessionExists(name string) bool {
-	cmd := tmux.cmd("has-session", "-t", name)
+	cmd := tmux.cmd("list-sessions", "-F", "#{session_name}")
 	res, err := tmux.commander.Exec(cmd)
-	return res == "" && err == nil
+	if err != nil {
+		return false
+	}
+
+	name = strings.Trim(name, ":")
+	for _, s := range strings.Split(strings.TrimSpace(res), "\n") {
+		if s == name {
+			return true
+		}
+	}
+	return false
 }
 
 func (tmux Tmux) KillWindow(target string) error {


### PR DESCRIPTION
Looks like by design `tmux has-session -t <name>` sends true for prefixed sessions.
So `tmux has-session -t test` returns true if there is an opened session named `test-abc`, see below example:

```bash
tmux list-sessions -F '#{session_name}'
test-abc

tmux has-session -t test && echo "yes"
yes

# true even when there is no a 'test' session
```

The fix is basically list all sessions with `tmux list-sessions -F '#{session_name}'` get all session names as a slice and compare if session exist in a loop

 This should be the right behavior when there is already a prefixed session name created like in the example (`test-abc`):
```bash
./smug-test test
Starting a new session...
DEBUG: test: exists:  false
```

- There is no a DEBUG message in the final fix, this was only for a dumb debug
- Mock tests were adjusted to work with the new method using `list-sessions`
- All test passed with no errors
```
go test .
ok      github.com/ivaaaan/smug (cached)
```