### PR TITLE
Fix #117: Adds "switch" command

### DIFF
--- a/completion/smug.bash
+++ b/completion/smug.bash
@@ -15,13 +15,13 @@ _smug() {
 
     # commands
     if (( "${#COMP_WORDS[@]}" == 2 )); then
-        reply=($(compgen -W "list print rm start stop" -- "${cur}"))
+        reply=($(compgen -W "list print rm start stop switch" -- "${cur}"))
     fi
 
     # projects
     if (( "${#COMP_WORDS[@]}" == 3 )); then
         case ${prev} in
-            start|stop|rm)
+            start|stop|rm|switch)
                 reply=($(compgen -W "$(smug list | grep -F -v smug)" -- "${cur}"))
         esac
     fi

--- a/completion/smug.fish
+++ b/completion/smug.fish
@@ -1,2 +1,3 @@
 complete -x -c smug -a "(ls ~/.config/smug | grep -v \"smug\.log\" | sed -e 's/\..*//')"
 complete -c smug -n '__fish_use_subcommand' -a 'rm' -d 'Remove project configuration'
+complete -c smug -n '__fish_use_subcommand' -a 'switch' -d 'Switch to a project session'

--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ Commands:
 	stop    stop project session
 	print   session configuration to stdout
 	rm      remove project configuration
+	switch  switch to a project session (alias for start -a)
 
 Examples:
 	$ smug list
@@ -50,6 +51,7 @@ Examples:
 	$ smug start blog --attach
 	$ smug print > ~/.config/smug/blog.yml
 	$ smug rm blog
+	$ smug switch blog
 `, version, FileUsage, WindowsUsage, AttachUsage, InsideCurrentSessionUsage, DebugUsage, DetachUsage)
 
 const (
@@ -130,8 +132,13 @@ func main() {
 	context := CreateContext()
 
 	switch options.Command {
-	case CommandStart:
+	case CommandStart, CommandSwitch:
 		configs := getConfigs(options, userConfigDir)
+
+		if options.Command == CommandSwitch && options.Project == "" {
+			fmt.Fprint(os.Stderr, "switch requires a project name")
+			os.Exit(1)
+		}
 
 		if len(options.Windows) == 0 {
 			fmt.Println("Starting a new session...")

--- a/main.go
+++ b/main.go
@@ -136,7 +136,7 @@ func main() {
 		configs := getConfigs(options, userConfigDir)
 
 		if options.Command == CommandSwitch && options.Project == "" {
-			fmt.Fprint(os.Stderr, "switch requires a project name")
+			fmt.Fprint(os.Stderr, "switch requires a project session")
 			os.Exit(1)
 		}
 

--- a/man/man1/smug.1
+++ b/man/man1/smug.1
@@ -69,6 +69,10 @@ Stop tmux project session
 Remove a project configuration. Asks for confirmation before deleting.
 
 .TP
+.B "switch [<projectname>]"
+Switch to a tmux project session. Alias for start --attach.
+
+.TP
 .B "print"
 Print current session configuration as yaml to stdout
 
@@ -90,6 +94,8 @@ $ smug start blog --attach
 $ smug print > ~/.config/smug/new_project.yml
 .br
 $ smug rm blog
+.br
+$ smug switch blog
 
 .SH AUTHOR
 Ivan Klymenchenko

--- a/options.go
+++ b/options.go
@@ -17,6 +17,7 @@ const (
 	CommandList   = "list"
 	CommandPrint  = "print"
 	CommandRemove = "rm"
+	CommandSwitch = "switch"
 )
 
 type command struct {
@@ -45,7 +46,7 @@ var Commands = commands{
 	},
 	{
 		Name:    CommandList,
-		Aliases: []string{"l"},
+		Aliases: []string{"l", "ls"},
 	},
 	{
 		Name:    CommandPrint,
@@ -54,6 +55,10 @@ var Commands = commands{
 	{
 		Name:    CommandRemove,
 		Aliases: []string{"r"},
+	},
+	{
+		Name:    CommandSwitch,
+		Aliases: []string{"sw"},
 	},
 }
 
@@ -168,7 +173,7 @@ func ParseOptions(argv []string) (*Options, error) {
 
 	settings := parseUserSettings(flags.Args()[1:])
 
-	return &Options{
+	opts := &Options{
 		Project:              project,
 		Config:               *config,
 		Command:              cmd.Name,
@@ -178,5 +183,11 @@ func ParseOptions(argv []string) (*Options, error) {
 		Detach:               *detach,
 		Debug:                *debug,
 		InsideCurrentSession: *insideCurrentSession,
-	}, nil
+	}
+
+	if cmd.Name == CommandSwitch {
+		opts.Attach = true
+	}
+
+	return opts, nil
 }

--- a/options_test.go
+++ b/options_test.go
@@ -243,6 +243,30 @@ var usageTestTable = []struct {
 		nil,
 		nil,
 	},
+	{
+		[]string{"switch", "blog"},
+		Options{
+			Command:  "switch",
+			Project:  "blog",
+			Windows:  []string{},
+			Attach:   true,
+			Settings: map[string]string{},
+		},
+		nil,
+		nil,
+	},
+	{
+		[]string{"sw", "blog"},
+		Options{
+			Command:  "switch",
+			Project:  "blog",
+			Windows:  []string{},
+			Attach:   true,
+			Settings: map[string]string{},
+		},
+		nil,
+		nil,
+	},
 }
 
 func TestParseOptions(t *testing.T) {


### PR DESCRIPTION
Adds `switch` command as an alias for `start <project> -a`

- In `options.go` file basically identifies if it's `switch` command then enables the `Attach` flag and continues the original logic
```go
if cmd.Name == CommandSwitch {
    opts.Attach = true
}
```

- If no session name is passed shows an error message
```bash
./smug-test switch
switch requires a project name
```
- If there is no a config file shows the proper error as `smug start`
```bash 
./smug-test switch XYZ
config not found for project XYZ
```

- Man pages, completions and test are updated
- All tests passed with no errors
```bash
 go test .
ok      github.com/ivaaaan/smug 0.925s
```