### PR TITLE
attach/detach hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,11 @@ You may also create a file named `.smug.yml` in the current working directory, w
 ### Session-level options
 
 - `attach` - Automatically attach to the session after creation (defaults to `false`). The `-a` flag can also enable attachment.
+- `before_start` - Runs only before session is created
+- `stop` - Runs only before session killed
+
+- `attach_hook` - Runs every time first client is attached to the session
+- `detach_hook` - Runs every time last client is detached to the session
 
 ### Examples
 
@@ -164,14 +169,19 @@ session: blog
 
 root: ~/Developer/blog
 
-before_start:
-  - docker-compose -f my-microservices/docker-compose.yml up -d # my-microservices/docker-compose.yml is a relative to `root`
-
 env:
   FOO: BAR
 
+before_start:
+  - docker-compose -f my-microservices/docker-compose.yml up -d # my-microservices/docker-compose.yml is a relative to `root`, runs only before session is
+
 stop:
-  - docker stop $(docker ps -q)
+  - docker stop $(docker ps -q) # runs only before session is killed
+
+attach_hook: echo 'test' > /tmp/SMUG-ATTACH-HOOK  # runs every time first client is attached to the session (different than "before_start")
+
+detach_hook: echo 'test' > /tmp/SMUG-DETACH-HOOK  # runs every time last client is detached from the session (different than "stop")
+
 
 windows:
   - name: code

--- a/config.go
+++ b/config.go
@@ -41,6 +41,9 @@ type Window struct {
 type Config struct {
 	SendKeysTimeout int    `yaml:"sendkeys_timeout"`
 	Session         string `yaml:"session"`
+	DetachHook	 	string `yaml:"detach_hook"`
+	AttachHook		string `yaml:"attach_hook"`
+
 	// Attach controls whether the session automatically attaches after creation.
 	// The -a/--attach CLI flag can also enable attachment.
 	Attach      bool              `yaml:"attach,omitempty"`

--- a/smug.go
+++ b/smug.go
@@ -125,6 +125,20 @@ func (smug Smug) Start(config *Config, options *Options, context Context) error 
 		if err != nil {
 			return err
 		}
+
+		if config.DetachHook != "" {
+			err = smug.tmux.SetHook(config.Session, "client-detached", config.DetachHook)
+			if err != nil {
+				return err
+			}
+		}
+		if config.AttachHook != "" {
+			err = smug.tmux.SetHook(config.Session, "client-attached", config.AttachHook)
+			if err != nil {
+				return err
+			}
+		}
+
 	} else if len(windows) == 0 && !createWindowsInsideCurrSession {
 		if options.Detach {
 			return nil

--- a/smug_test.go
+++ b/smug_test.go
@@ -237,6 +237,36 @@ var testTable = map[string]struct {
 		},
 		[]string{"ses", ""},
 	},
+	"test with attach and detach hooks": {
+		&Config{
+			Session:    "ses",
+			Root:       "root",
+			DetachHook: "echo detached",
+			AttachHook: "echo attached",
+			Windows: []Window{
+				{
+					Name: "win1",
+				},
+			},
+		},
+		&Options{},
+		Context{},
+		[]string{
+			"tmux list-sessions -F #{session_name}",
+			"tmux new -Pd -s ses -n smug_def -c root",
+			`tmux set-hook -t ses client-detached if -F "#{==:#{session_attached},0}" "run-shell \"echo detached\""`,
+			`tmux set-hook -t ses client-attached if -F "#{==:#{session_attached},1}" "run-shell \"echo attached\""`,
+			"tmux neww -Pd -t ses: -c root -F #{window_id} -n win1",
+			"tmux select-layout -t xyz even-horizontal",
+			"tmux kill-window -t ses:smug_def",
+			"tmux move-window -r -s ses: -t ses:",
+			"tmux attach -d -t ses:win1",
+		},
+		[]string{
+			"tmux kill-session -t ses",
+		},
+		[]string{"xyz"},
+	},
 	"test create new windows in current session with different name": {
 		&Config{
 			Session: "ses",


### PR DESCRIPTION
This adds `attach_hook` & `detach_hook` feature
- `attach_hook` runs every time first client is attached to the session
- `detach_hook` runs every time last client is detached from the session




See below test with a test config

```yml
session: test
root: ${HOME}
attach_hook: echo 'test' > /tmp/SMUG-ATTACH-HOOK
detach_hook: echo 'test' > /tmp/SMUG-DETACH-HOOK
windows:
- name: smug-1
  selected: true
- name: smug-2
  selected: false
```

- That config creates these two `tmux hooks`
```bash
$ tmux show-hooks -t test
client-attached[0] if-shell -F "#{==:#{session_attached},1}" "run-shell \"echo 'test' > /tmp/SMUG-ATTACH-HOOK\""
client-detached[0] if-shell -F "#{==:#{session_attached},0}" "run-shell \"echo 'test' > /tmp/SMUG-DETACH-HOOK\""
```

- test files are created as per commands in the config

```bash
# delete previous test files
$ rm /tmp/SMUG*

# start and attach new session
$ smug start test

# once smug creates the session and first client is attached
$ cat /tmp/SMUG-ATTACH-HOOK
test

# when last client detach from session
# [detached (from session test)]
$ cat /tmp/SMUG-DETACH-HOOK
test
```

I added the proper tests and all passed ok
```bash
$ go test .
ok  	github.com/ivaaaan/smug	0.518s
```

I also updated the examples in the `README.md` file